### PR TITLE
Updates PHPCS configuration to drop PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,19 @@ matrix:
 
   include:
     # Declare versions of PHP to use. Use one decimal max.
-    - php: '5.3'
-      env: PHPCS_BRANCH=2.9.1 PHPCS_SCRIPT=scripts SNIFF=1
+    # We sniff the current and +1 release of PHP, and just run syntax checking
+    # for others.
+    - php: 'nightly'
+    - php: '7.3'
+    - php: '7.2'
+      env: PHPCS_BRANCH=master PHPCS_SCRIPT=bin SNIFF=1
     - php: '7.1'
       env: PHPCS_BRANCH=master PHPCS_SCRIPT=bin SNIFF=1
-    - php: 'nightly'
 
   allow_failures:
     - php: "nightly"
-    - php: "7.1"
+    - php: "7.3"
+    - php: "7.2"
 
 # Use this to prepare the system to install prerequisites or dependencies.
 # e.g. sudo apt-get update.
@@ -43,7 +47,7 @@ before_script:
   - export PHPCS_DIR=/tmp/phpcs
   # Define WordPress Coding Standards
   - export WPCS_DIR=/tmp/wpcs
-  - export WPCS_BRANCH=1.2.1
+  - export WPCS_BRANCH=master
   # Install WordPress Coding Standards (master branch, not develop).
   - if [[ "$SNIFF" == "1" ]]; then git clone -b $WPCS_BRANCH https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
   # Install CodeSniffer for WordPress Coding Standards checks (pre 3.x version).
@@ -59,8 +63,9 @@ before_script:
 # Default is specific to project language.
 # All commands must exit with code 0 on success. Anything else is considered failure.
 script:
-  # Search for PHP syntax errors.
-  - find . \( -name '*.php' \) -exec php -lf {} \;
+  # Search for PHP syntax errors outside the libs directory
+  # @link http://stackoverflow.com/questions/4210042/exclude-directory-from-find-command
+  - find . -path ./libs -prune -o \( -name '*.php' \) -exec php -lf {} \;
   # WordPress Coding Standards
   # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
   # @link http://pear.php.net/package/PHP_CodeSniffer/

--- a/codesniffer.mitlib.xml
+++ b/codesniffer.mitlib.xml
@@ -18,11 +18,9 @@
 		<exclude name="WordPress.CodeAnalysis" />
 		<exclude name="WordPress.DB" />
 		<exclude name="WordPress.Files" />
-		<exclude name="WordPress.Functions" />
 		<exclude name="WordPress.NamingConventions" />
 		<exclude name="WordPress.PHP" />
 		<exclude name="WordPress.Utils" />
-		<exclude name="WordPress.Variables" />
 		<exclude name="WordPress.WP" />
 		<exclude name="WordPress.WhiteSpace" />
 	</rule>


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This updates the PHPCS configuration to match that used by our themes:
- Using the current release of PHPCS (when we supported PHP 5.3 we had to use an older version)
- Testing against current PHP version (7.1 - 7.3, allowing failures for 7.2 and 7.3)
- Checking only security-related problems, leaving other tests to CodeClimate (which does better at testing only changed lines)

#### Helpful background context (if appropriate)
The reference implementation for themes is the Parent theme - https://github.com/mitlibraries/mitlibraries-parent

#### How can a reviewer manually see the effects of these changes?
Check the results of the Travis review below. Ideally it will pass (which is the case in this repo). It should at least return a failed result (successfully ending, and flagging problems if they exist) rather than erroring.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-529

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
